### PR TITLE
GHO-9342: Handle Classic Load Balancer logs

### DIFF
--- a/log_conversion.tf
+++ b/log_conversion.tf
@@ -98,5 +98,11 @@ resource "aws_s3_bucket_notification" "input" {
     filter_suffix       = ".gz"
   }
 
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.log_converter.arn
+    events              = ["s3:ObjectCreated:Put"]
+    filter_suffix       = ".log"
+  }
+
   depends_on = [aws_lambda_permission.log_converter]
 }

--- a/log_conversion.tf
+++ b/log_conversion.tf
@@ -94,13 +94,13 @@ resource "aws_s3_bucket_notification" "input" {
 
   lambda_function {
     lambda_function_arn = aws_lambda_function.log_converter.arn
-    events              = ["s3:ObjectCreated:Put"]
+    events              = ["s3:ObjectCreated:*"]
     filter_suffix       = ".gz"
   }
 
   lambda_function {
     lambda_function_arn = aws_lambda_function.log_converter.arn
-    events              = ["s3:ObjectCreated:Put"]
+    events              = ["s3:ObjectCreated:*"]
     filter_suffix       = ".log"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  lambda_image = "007807482039.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/forwarder:v0.5.1"
+  lambda_image = "007807482039.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/forwarder:v0.5.3"
   default_tags = {
     "ghost:forwarder_name" = var.name
   }


### PR DESCRIPTION
<!-- Let's keep this simple with a basic outline for the PR -->
<!-- If this template isn't applicable, delete the content and write something helpful -->
<!-- If this pull request closes an issue, please mention the issue number below -->

#### 👻 Ghost Linear Issue
https://linear.app/ghostsecurity/issue/GHO-9342/terraform-module-supports-log-files

### 📑 Description (what does this PR add, change, remove)
Handle [AWS Classic Load balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html) logs:
- Process files wth `.log` extension which are not gzipped and in the AWS Classic Load Balancer logging format.
- Trigger on all ObjectCreated events

### ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code required changes to the documentation; I've included those changes
- [ ] I've added tests to support this change (where applicable)

<!-- Any screenshots or output which might help clarify what this PR is doing -->
